### PR TITLE
Update API endpoint URL and rename asset_file to file in requests

### DIFF
--- a/nuxeo-loci-ai-3d-connector-core/src/main/java/org/nuxeo/labs/loci/ai/core/enricher/LociAiEnrichmentProvider.java
+++ b/nuxeo-loci-ai-3d-connector-core/src/main/java/org/nuxeo/labs/loci/ai/core/enricher/LociAiEnrichmentProvider.java
@@ -97,7 +97,7 @@ public class LociAiEnrichmentProvider extends RestEnrichmentProvider {
             // Use the multipart builder
             MultipartEntityBuilder multipartBuilder = MultipartEntityBuilder.create();
             multipartBuilder.setContentType(ContentType.MULTIPART_FORM_DATA);
-            multipartBuilder.addBinaryBody("asset_file", closeableFile.getFile(),
+            multipartBuilder.addBinaryBody("file", closeableFile.getFile(),
                     ContentType.DEFAULT_BINARY, String.format("%s.%s",closeableFile.getFile().getName(),extension));
             requestBuilder.setEntity(multipartBuilder.build());
             // Build the request

--- a/nuxeo-loci-ai-3d-connector-core/src/main/resources/OSGI-INF/enrichment-provider-contrib.xml
+++ b/nuxeo-loci-ai-3d-connector-core/src/main/resources/OSGI-INF/enrichment-provider-contrib.xml
@@ -10,7 +10,7 @@
             <mimeTypes>
                 <mimeType name="model/gltf-binary"/>
             </mimeTypes>
-            <option name="uri">https://prod.loci-api.com/tag/tag-3d-asset</option>
+            <option name="uri">https://loci-api.com/3d/tag</option>
             <option name="headers.default">false</option>
             <option name="minConfidence">0.75</option>
             <option name="apiKey">${nuxeo.ai.loci.apiKey}</option>


### PR DESCRIPTION
Hi there

We've added a little update to what we could see needed changing for our upcoming API breaking changes. 

To recap:

1. Change the parameter for the tagging endpoint from `asset_file` to `file`
2. Change the reference to the old endpoint from `https://prod.loci-api.com/tag/tag-3d-asset`  to `https://loci-api.com/3d/tag`

We are also adding some extra parameters that you might want to implement, such as `additional_text_context`, further details can be seen in our, yet to be released, dev OpenApiSpec: https://dev.loci-api.com/docs#/3D%20Asset/tag_asset_3d_tag_post

We've noticed you use an environment variable to point to the tagging endpoint but feel free to amend if needed. 



